### PR TITLE
Single collateral

### DIFF
--- a/apps/aragon-fundraising/app/src/App.js
+++ b/apps/aragon-fundraising/app/src/App.js
@@ -15,7 +15,7 @@ const App = () => {
   // *****************************
   // background script state
   // *****************************
-  const { isReady, collateralsAreOk, addresses, presale } = useAppState()
+  const { isReady, addresses, presale } = useAppState()
 
   // *****************************
   // aragon api
@@ -60,9 +60,8 @@ const App = () => {
   return (
     <Main theme={appearance} assetsUrl="./aragon-ui">
       <SyncIndicator visible={!isReady || isPresale === null} />
-      {isPresale && isReady && collateralsAreOk && <PresaleView />}
-      {!isPresale && isReady && collateralsAreOk && <MainView />}
-      {isReady && !collateralsAreOk && <CollateralError />}
+      {isPresale && isReady && <PresaleView />}
+      {!isPresale && isReady && <MainView />}
     </Main>
   )
 }

--- a/apps/aragon-fundraising/app/src/appStateReducer/index.js
+++ b/apps/aragon-fundraising/app/src/appStateReducer/index.js
@@ -1,6 +1,5 @@
 import {
   ready,
-  checkCollaterals,
   computeConstants,
   computeValues,
   computePresale,
@@ -32,7 +31,6 @@ const appStateReducer = state => {
       isReady,
       constants: computedConstants,
       values: computedValues,
-      collateralsAreOk: checkCollaterals(collaterals, network),
       presale: computedPresale,
       // we don't compute BigNumbers on contributions, since it's only necessary if the presale state is refund
       // we will compute the BigNumbers on the newRefund panel

--- a/apps/aragon-fundraising/app/src/appStateReducer/utils.js
+++ b/apps/aragon-fundraising/app/src/appStateReducer/utils.js
@@ -17,28 +17,6 @@ export const ready = state => {
   return synced && hasCollaterals && hasTaps && presaleStateIsKnown
 }
 
-/**
- * DAI and ANT are the only collaterals accepted to start the app on rinkeby or mainnet
- * @param {Map} collaterals - collaterals found in the app
- * @param {Object} network - id and type of the network
- * @returns {boolean} true if network is rinkeby or mainnet and collaterals are the good ones, true no matter what on any other networks
- */
-export const checkCollaterals = (collaterals, { type }) => {
-  if (type === 'main' || type === 'rinkeby') {
-    // verified addresses
-    const realDaiAddress = Tokens[type].DAI.toLowerCase()
-    const realAntAddress = Tokens[type].ANT.toLowerCase()
-    // get DAI and ANT addresses from the fundraising app
-    const currentCollaterals = Array.from(collaterals).map(([address, { symbol }]) => ({ address, symbol }))
-    console.log('currentCollaterals', currentCollaterals);
-    const daiAddress = currentCollaterals.find(c => c.symbol === defaultTokenSymbol).address
-    const antAddress = currentCollaterals.find(c => c.symbol === 'ANT').address
-    // check they are the same
-    const sameDai = daiAddress?.toLowerCase() === realDaiAddress
-    const sameAnt = antAddress?.toLowerCase() === realAntAddress
-    return sameDai && sameAnt
-  } else return true
-}
 
 /**
  * Converts constants to big numbers
@@ -114,10 +92,8 @@ export const computeCollaterals = collaterals => {
   const computedCollaterals = Array.from(cloneDeep(collaterals))
   console.log('currentCollaterals', computedCollaterals);
   const [daiAddress, daiData] = computedCollaterals.find(([_, data]) => data.symbol === defaultTokenSymbol)
-  const [antAddress, antData] = computedCollaterals.find(([_, data]) => data.symbol === 'ANT')
   return {
     dai: transformCollateral(daiAddress, daiData),
-    ant: transformCollateral(antAddress, antData),
   }
 }
 
@@ -127,7 +103,7 @@ export const computeCollaterals = collaterals => {
  * @param {Object} collaterals - fundraising collaterals
  * @returns {Object} the computed bondedToken
  */
-export const computeBondedToken = (bondedToken, { dai, ant }) => {
+export const computeBondedToken = (bondedToken, { dai }) => {
   const totalSupply = new BigNumber(bondedToken.totalSupply)
   const toBeMinted = new BigNumber(bondedToken.toBeMinted)
   const realSupply = totalSupply.plus(toBeMinted)
@@ -138,7 +114,6 @@ export const computeBondedToken = (bondedToken, { dai, ant }) => {
     realSupply,
     overallSupply: {
       dai: realSupply.plus(dai.virtualSupply),
-      ant: realSupply.plus(ant.virtualSupply),
     },
   }
 }

--- a/apps/aragon-fundraising/app/src/components/NewOrder/Order.js
+++ b/apps/aragon-fundraising/app/src/components/NewOrder/Order.js
@@ -27,7 +27,7 @@ const Order = ({ isBuyOrder }) => {
   // *****************************
   // context state
   // *****************************
-  const { orderPanel, setOrderPanel, userBondedTokenBalance, userDaiBalance, userAntBalance } = useContext(MainViewContext)
+  const { orderPanel, setOrderPanel, userBondedTokenBalance, userDaiBalance } = useContext(MainViewContext)
 
   // *****************************
   // internal state
@@ -105,7 +105,7 @@ const Order = ({ isBuyOrder }) => {
   }
 
   const getUserBalance = () => {
-    const balance = isBuyOrder ? [userDaiBalance, userAntBalance][selectedCollateral] : userBondedTokenBalance
+    const balance = isBuyOrder ? [userDaiBalance][selectedCollateral] : userBondedTokenBalance
     const decimals = isBuyOrder ? collateralItems[selectedCollateral].decimals : bondedDecimals
     return formatBigNumber(balance, decimals)
   }

--- a/apps/aragon-fundraising/app/src/components/NewOrder/Total.js
+++ b/apps/aragon-fundraising/app/src/components/NewOrder/Total.js
@@ -61,11 +61,10 @@ const Total = ({ isBuyOrder, amount, conversionSymbol, onError }) => {
       const valueBn = toDecimals(value, decimals)
       // supply, balance, weight, amount
       const currentSymbol = isBuyOrder ? symbol : conversionSymbol
-      const { defaultTokenSymbol } = require('../../../../../../config')
-      const supply = currentSymbol === defaultTokenSymbol ? overallSupply.dai : overallSupply.dai
-      const balance = currentSymbol === defaultTokenSymbol ? daiBalance : daiBalance
+      const supply = currentSymbol === overallSupply.dai
+      const balance = currentSymbol === daiBalance
       // slippage
-      const currentSlippage = currentSymbol === defaultTokenSymbol ? daiSlippageDec : daiSlippageDec
+      const currentSlippage = currentSymbol === daiSlippageDec
       // unit prices
       const maxPrice = new BigNumber(price).times(new BigNumber(1).plus(currentSlippage))
       const minPrice = new BigNumber(price).times(new BigNumber(1).minus(currentSlippage))
@@ -90,8 +89,7 @@ const Total = ({ isBuyOrder, amount, conversionSymbol, onError }) => {
       }
     }
 
-    const { defaultTokenSymbol } = require('../../../../../../config')
-    const userBalance = symbol === defaultTokenSymbol ? userDaiBalance : userDaiBalance
+    const userBalance = symbol === userDaiBalance
     if (isBuyOrder && userBalance.lt(toDecimals(value, decimals))) {
       // cannot buy more than your own balance
       setFormattedAmount(formatBigNumber(value, 0))

--- a/apps/aragon-fundraising/app/src/components/NewOrder/Total.js
+++ b/apps/aragon-fundraising/app/src/components/NewOrder/Total.js
@@ -18,11 +18,9 @@ const Total = ({ isBuyOrder, amount, conversionSymbol, onError }) => {
     bondedToken: { overallSupply },
     collaterals: {
       dai: { slippage: daiSlippage },
-      ant: { slippage: antSlippage },
     },
   } = useAppState()
   const daiSlippageDec = daiSlippage.div(PCT_BASE)
-  const antSlippageDec = antSlippage.div(PCT_BASE)
 
   // *****************************
   // aragon api
@@ -33,7 +31,7 @@ const Total = ({ isBuyOrder, amount, conversionSymbol, onError }) => {
   // *****************************
   // context state
   // *****************************
-  const { price, daiBalance, antBalance, userDaiBalance, userAntBalance, userBondedTokenBalance } = useContext(MainViewContext)
+  const { price, daiBalance, antBalance, userDaiBalance, userBondedTokenBalance } = useContext(MainViewContext)
 
   // *****************************
   // internal state
@@ -64,10 +62,10 @@ const Total = ({ isBuyOrder, amount, conversionSymbol, onError }) => {
       // supply, balance, weight, amount
       const currentSymbol = isBuyOrder ? symbol : conversionSymbol
       const { defaultTokenSymbol } = require('../../../../../../config')
-      const supply = currentSymbol === defaultTokenSymbol ? overallSupply.dai : overallSupply.ant
-      const balance = currentSymbol === defaultTokenSymbol ? daiBalance : antBalance
+      const supply = currentSymbol === defaultTokenSymbol ? overallSupply.dai : overallSupply.dai
+      const balance = currentSymbol === defaultTokenSymbol ? daiBalance : daiBalance
       // slippage
-      const currentSlippage = currentSymbol === defaultTokenSymbol ? daiSlippageDec : antSlippageDec
+      const currentSlippage = currentSymbol === defaultTokenSymbol ? daiSlippageDec : daiSlippageDec
       // unit prices
       const maxPrice = new BigNumber(price).times(new BigNumber(1).plus(currentSlippage))
       const minPrice = new BigNumber(price).times(new BigNumber(1).minus(currentSlippage))
@@ -93,7 +91,7 @@ const Total = ({ isBuyOrder, amount, conversionSymbol, onError }) => {
     }
 
     const { defaultTokenSymbol } = require('../../../../../../config')
-    const userBalance = symbol === defaultTokenSymbol ? userDaiBalance : userAntBalance
+    const userBalance = symbol === defaultTokenSymbol ? userDaiBalance : userDaiBalance
     if (isBuyOrder && userBalance.lt(toDecimals(value, decimals))) {
       // cannot buy more than your own balance
       setFormattedAmount(formatBigNumber(value, 0))

--- a/apps/aragon-fundraising/app/src/screens/Orders.js
+++ b/apps/aragon-fundraising/app/src/screens/Orders.js
@@ -86,7 +86,6 @@ export default ({ myOrders }) => {
     orders,
     collaterals: {
       dai: { decimals: daiDecimals },
-      ant: { decimals: antDecimals },
     },
     bondedToken: { decimals: tokenDecimals },
   } = useAppState()

--- a/apps/aragon-fundraising/app/src/screens/Reserves.js
+++ b/apps/aragon-fundraising/app/src/screens/Reserves.js
@@ -75,7 +75,6 @@ export default () => {
         decimals: daiDecimals,
         tap: { rate, floor, timestamp },
       },
-      ant: { reserveRatio: antReserveRatio, symbol: antSymbol },
     },
     bondedToken: { name, symbol, decimals: tokenDecimals, address, realSupply },
   } = useAppState()
@@ -97,7 +96,6 @@ export default () => {
   const displayRateIncrease = formatBigNumber(adjustedRateIncrease.times(100), 0, 0)
   const displayFloorIncrease = formatBigNumber(adjustedFloorDecrease.times(100), 0, 0)
   const daiRatio = formatBigNumber(daiReserveRatio.div(PPM).times(100), 0)
-  const antRatio = formatBigNumber(antReserveRatio.div(PPM).times(100), 0)
   const adjustedMaxRate = formatBigNumber(adjustedRate.plus(adjustedRate.times(maximumTapRateIncreasePct).div(PCT_BASE)), daiDecimals)
   const adjustedMinFloor = formatBigNumber(floor.minus(floor.times(maximumTapFloorDecreasePct).div(PCT_BASE)), daiDecimals)
 

--- a/apps/aragon-fundraising/app/src/views/MainView.js
+++ b/apps/aragon-fundraising/app/src/views/MainView.js
@@ -29,7 +29,6 @@ export default () => {
     },
     collaterals: {
       dai: { address: daiAddress, reserveRatio, toBeClaimed: daiToBeClaimed, virtualBalance: daiVirtualBalance, overallBalance: daiOverallBalance },
-      ant: { address: antAddress, toBeClaimed: antToBeClaimed, virtualBalance: antVirtualBalance, overallBalance: antOverallBalance },
     },
   } = useAppState()
 
@@ -57,37 +56,32 @@ export default () => {
   // *****************************
   const [polledReserveBalance, setPolledReserveBalance] = useState(null)
   const [polledDaiBalance, setPolledDaiBalance] = useState(daiOverallBalance)
-  const [polledAntBalance, setPolledAntBalance] = useState(antOverallBalance)
   const [polledBatchId, setPolledBatchId] = useState(null)
   const [polledPrice, setPolledPrice] = useState(0)
   const [userBondedTokenBalance, setUserBondedTokenBalance] = useState(new BigNumber(0))
   const [userDaiBalance, setUserDaiBalance] = useState(new BigNumber(0))
-  const [userAntBalance, setUserAntBalance] = useState(new BigNumber(0))
 
   // react context accessible on child components
   const context = {
     reserveBalance: polledReserveBalance,
     daiBalance: polledDaiBalance,
-    antBalance: polledAntBalance,
     batchId: polledBatchId,
     price: polledPrice,
     orderPanel,
     setOrderPanel,
     userBondedTokenBalance,
     userDaiBalance,
-    userAntBalance,
   }
 
   // watch for a connected user and get its balances
   useEffect(() => {
     const getUserBalances = async () => {
-      const balancesPromises = [bondedTokenAddress, daiAddress, antAddress].map(address => api.call('balanceOf', connectedUser, address).toPromise())
-      const [bondedBalance, daiBalance, antBalance] = await Promise.all(balancesPromises)
+      const balancesPromises = [bondedTokenAddress, daiAddress].map(address => api.call('balanceOf', connectedUser, address).toPromise())
+      const [bondedBalance, daiBalance] = await Promise.all(balancesPromises)
       // TODO: keep an eye on React 17, since all updates will be batched by default
       batchedUpdates(() => {
         setUserBondedTokenBalance(new BigNumber(bondedBalance))
         setUserDaiBalance(new BigNumber(daiBalance))
-        setUserAntBalance(new BigNumber(antBalance))
       })
     }
     if (connectedUser) {
@@ -99,21 +93,18 @@ export default () => {
   useInterval(async () => {
     // polling balances and batchId
     const daiPromise = api.call('balanceOf', pool, daiAddress).toPromise()
-    const antPromise = api.call('balanceOf', pool, antAddress).toPromise()
     const batchIdPromise = marketMakerContract.getCurrentBatchId().toPromise()
-    const [daiBalance, antBalance, batchId] = await Promise.all([daiPromise, antPromise, batchIdPromise])
+    const [daiBalance, batchId] = await Promise.all([daiPromise, batchIdPromise])
     const newReserveBalance = new BigNumber(daiBalance)
     const newDaiBalance = new BigNumber(daiBalance).minus(daiToBeClaimed).plus(daiVirtualBalance)
-    const newAntBalance = new BigNumber(antBalance).minus(antToBeClaimed).plus(antVirtualBalance)
     const newBatchId = parseInt(batchId, 10)
     // poling user balances
-    let newUserBondedTokenBalance, newUserDaiBalance, newUserAntBalance
+    let newUserBondedTokenBalance, newUserDaiBalance
     if (connectedUser) {
-      const balancesPromises = [bondedTokenAddress, daiAddress, antAddress].map(address => api.call('balanceOf', connectedUser, address).toPromise())
-      const [bondedBalance, daiBalance, antBalance] = await Promise.all(balancesPromises)
+      const balancesPromises = [bondedTokenAddress, daiAddress].map(address => api.call('balanceOf', connectedUser, address).toPromise())
+      const [bondedBalance, daiBalance] = await Promise.all(balancesPromises)
       newUserBondedTokenBalance = new BigNumber(bondedBalance)
       newUserDaiBalance = new BigNumber(daiBalance)
-      newUserAntBalance = new BigNumber(antBalance)
     }
     // polling price
     const price = await marketMakerContract.getStaticPricePPM(daiSupply.toFixed(), polledDaiBalance.toFixed(), reserveRatio.toFixed()).toPromise()
@@ -125,14 +116,12 @@ export default () => {
       // update the state only if value changed
       if (!newReserveBalance.eq(polledReserveBalance)) setPolledReserveBalance(newReserveBalance)
       if (!newDaiBalance.eq(polledDaiBalance)) setPolledDaiBalance(newDaiBalance)
-      if (!newAntBalance.eq(polledAntBalance)) setPolledAntBalance(newAntBalance)
       if (newBatchId !== polledBatchId) setPolledBatchId(newBatchId)
       if (!newPrice.eq(polledPrice)) setPolledPrice(newPrice)
       // update user balances
       if (connectedUser) {
         if (!newUserBondedTokenBalance.eq(userBondedTokenBalance)) setUserBondedTokenBalance(newUserBondedTokenBalance)
         if (!newUserDaiBalance.eq(userDaiBalance)) setUserDaiBalance(newUserDaiBalance)
-        if (!newUserAntBalance.eq(userAntBalance)) setUserAntBalance(newUserAntBalance)
       }
     })
   }, Polling.DURATION)

--- a/apps/aragon-fundraising/contracts/AragonFundraisingController.sol
+++ b/apps/aragon-fundraising/contracts/AragonFundraisingController.sol
@@ -142,7 +142,7 @@ contract AragonFundraisingController is EtherTokenConstant, IsContract, IAragonF
      * @notice Contribute to the presale up to `@tokenAmount(self.contributionToken(): address, _value)`
      * @param _value The amount of contribution token to be spent
     */
-    function contribute(uint256 _value) external payable auth(CONTRIBUTE_ROLE) {
+    function contribute(uint256 _value) external payable authP(CONTRIBUTE_ROLE, arr(msg.sender)) {
         presale.contribute.value(msg.value)(msg.sender, _value);
     }
 


### PR DESCRIPTION
I tried to remove the secondary token from the initialization in the gardens template and found that the fundraising app wouldn't load. This PR removes references to a secondary token from the app making it possible to run with a single collateral. It should be possible still to add a second collateral but it will not be possible to interact with this second reserve from the frontend. 

There are some instances where a conditional was used to toggle between the two, in these cases I left the conditional but just had both possible outcomes use the dai token--this should probably be improved but just wanted to get it working. 

Similarly, right now the single collateral is referenced as DAI, but it probably should be something like currencyToken or something along those lines. 🤷‍♂️