### PR TITLE
New Order panel general fixes

### DIFF
--- a/apps/aragon-fundraising/app/.eslintrc.json
+++ b/apps/aragon-fundraising/app/.eslintrc.json
@@ -26,6 +26,8 @@
       }
     ],
     "func-style": ["error", "expression"],
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
     "linebreak-style": ["error", "unix"]
   }
 }

--- a/apps/aragon-fundraising/app/src/abi/token-manager.json
+++ b/apps/aragon-fundraising/app/src/abi/token-manager.json
@@ -1,0 +1,21 @@
+[ 
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_holder",
+        "type": "address"
+      }
+    ],
+    "name": "spendableBalanceOf",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/apps/aragon-fundraising/app/src/components/NewOrder/Info.js
+++ b/apps/aragon-fundraising/app/src/components/NewOrder/Info.js
@@ -1,9 +1,7 @@
 import React from 'react'
-import { useAppState, GU } from '@aragon/api-react'
-import { Info } from '@aragon/ui'
+import { GU, Info } from '@aragon/ui'
 
-const Information = ({minExpectedReturnAmount, tokenSymbol}) => {
-
+const Information = ({ minExpectedReturnAmount, tokenSymbol }) => {
   return (
     <div
       css={`

--- a/apps/aragon-fundraising/app/src/components/NewOrder/Order.js
+++ b/apps/aragon-fundraising/app/src/components/NewOrder/Order.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useCallback, useContext, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 import { useApi, useAppState } from '@aragon/api-react'
-import { Button, DropDown, Info, Text, TextInput, theme, unselectable, GU } from '@aragon/ui'
+import { Button, DropDown, GU, Info, Text, TextInput, theme, unselectable, useTheme } from '@aragon/ui'
 import { MainViewContext } from '../../context'
 import Total from './Total'
 import Info_ from './Info'
@@ -176,9 +176,9 @@ const Order = ({ isBuyOrder }) => {
             <DropDown items={[collaterals.primaryCollateral.symbol]} selected={selectedCollateral} onChange={setSelectedCollateral} css="width: 130px;" />
           </CombinedInput>
           <label>
-            <StyledTextBlock>ACCEPTED SLIPPAGE %</StyledTextBlock>
+            <StyledTextBlock>ACCEPTED SLIPPAGE</StyledTextBlock>
           </label>
-          <TextInput type="number" value={slippagePercent} onChange={handleSlippageUpdated} min={0} max={100} placeholder="0" step="any" required wide />
+          <PercentageInput value={slippagePercent} onChange={handleSlippageUpdated} />
         </AmountField>
       </InputsWrapper>
       <Total
@@ -235,6 +235,37 @@ const Order = ({ isBuyOrder }) => {
         )}
       </div>
     </form>
+  )
+}
+
+const PercentageInput = ({ value, onChange }) => {
+  const theme = useTheme()
+  const adornmentSettings = { padding: 1 }
+
+  return (
+    <TextInput
+      type="number"
+      value={value}
+      onChange={onChange}
+      wide
+      required
+      min={0}
+      max={100}
+      placeholder="0"
+      adornment={
+        <span
+          css={`
+            background: ${theme.background};
+            border-left: 1px solid ${theme.border};
+            padding: 7px ${2 * GU}px;
+          `}
+        >
+          %
+        </span>
+      }
+      adornmentPosition="end"
+      adornmentSettings={adornmentSettings}
+    />
   )
 }
 

--- a/apps/aragon-fundraising/app/src/components/NewOrder/Order.js
+++ b/apps/aragon-fundraising/app/src/components/NewOrder/Order.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext, useRef, useState } from 'react'
+import React, { useEffect, useCallback, useContext, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 import { useApi, useAppState } from '@aragon/api-react'
 import { Button, DropDown, Info, Text, TextInput, theme, unselectable, GU } from '@aragon/ui'
@@ -19,7 +19,7 @@ const Order = ({ isBuyOrder }) => {
     collaterals,
     bondedToken: { decimals: bondedDecimals, symbol: bondedSymbol },
   } = useAppState()
-  const collateralItems = [collaterals.primaryCollateral]
+  const collateralItems = useMemo(() => [collaterals.primaryCollateral], [collaterals])
 
   // *****************************
   // aragon api
@@ -56,34 +56,36 @@ const Order = ({ isBuyOrder }) => {
       setErrorMessage(null)
       // focus the right input, given the order type
       // timeout to avoid some flicker
-      amountInput && setTimeout(() => amountInput.current.focus(), 100)
+      amountInput.current && setTimeout(() => amountInput.current.focus(), 100)
     }
   }, [orderPanel, isBuyOrder])
 
   // *****************************
   // handlers
   // *****************************
-  const handleAmountUpdate = event => {
+  const handleAmountUpdate = useCallback(event => {
     setAmount(event.target.value)
-  }
+  }, [])
 
-  const handleSlippageUpdated = event => {
+  const handleSlippageUpdated = useCallback(event => {
     const value = event.target.value
     if (value >= 0 && value <= 100) {
       setSlippagePercent(event.target.value)
     }
-  }
+  }, [])
 
-  const validate = (err, message) => {
+  const validate = useCallback((err, message) => {
     setValid(err)
     setErrorMessage(message)
-  }
+  }, [])
 
   const handleSubmit = event => {
     event.preventDefault()
     const address = collateralItems[selectedCollateral].address
     if (valid) {
       const amountBn = toDecimals(amount, isBuyOrder ? collateralItems[selectedCollateral].decimals : bondedDecimals).toFixed()
+
+      console.log('minReturnAmount', minReturnAmount)
       const minReturnBn = toDecimals(minReturnAmount, isBuyOrder ? bondedDecimals : collateralItems[selectedCollateral].decimals).toFixed()
       if (isBuyOrder) {
         const intent = { token: { address, value: amountBn, spender: marketMaker } }
@@ -101,35 +103,47 @@ const Order = ({ isBuyOrder }) => {
     }
   }
 
-  const getDecimals = () => {
+  const getDecimals = useCallback(() => {
     return isBuyOrder ? collateralItems[selectedCollateral].decimals : bondedDecimals
-  }
+  }, [bondedDecimals, collateralItems, isBuyOrder, selectedCollateral])
 
-  const getSymbol = () => {
+  const getSymbol = useCallback(() => {
     return isBuyOrder ? collateralItems[selectedCollateral].symbol : bondedSymbol
-  }
+  }, [bondedSymbol, collateralItems, isBuyOrder, selectedCollateral])
 
-  const getConversionSymbol = () => {
+  const getConversionSymbol = useCallback(() => {
     return isBuyOrder ? bondedSymbol : collateralItems[selectedCollateral].symbol
-  }
+  }, [bondedSymbol, collateralItems, isBuyOrder, selectedCollateral])
 
-  const getReserveRatio = () => {
-    return collateralItems[selectedCollateral].reserveRatio
-  }
-
-  const getUserBalance = () => {
+  const getUserBalance = useCallback(() => {
     const balance = isBuyOrder ? [userPrimaryCollateralBalance][selectedCollateral] : userBondedTokenBalance
     const decimals = isBuyOrder ? collateralItems[selectedCollateral].decimals : bondedDecimals
     return formatBigNumber(balance, decimals)
-  }
+  }, [bondedDecimals, collateralItems, isBuyOrder, selectedCollateral, userBondedTokenBalance, userPrimaryCollateralBalance])
 
-  const percentageOf = (numberWithDecimals) => {
-    return numberWithDecimals.div(PCT_BASE).times(100).toFixed(2, 1)
-  }
+  const getFeePercentage = useCallback(() => {
+    const percentageOf = numberWithDecimals => {
+      return numberWithDecimals
+        .div(PCT_BASE)
+        .times(100)
+        .toFixed(2, 1)
+    }
 
-  const getFeePercentage = () => {
     return isBuyOrder ? percentageOf(buyFeePct) : percentageOf(sellFeePct)
-  }
+  }, [buyFeePct, isBuyOrder, PCT_BASE, sellFeePct])
+
+  const amountData = useMemo(() => {
+    const reserveRatio = collateralItems[selectedCollateral].reserveRatio
+
+    return {
+      value: amount,
+      decimals: getDecimals(),
+      symbol: getSymbol(),
+      reserveRatio,
+      feePercentage: getFeePercentage(),
+      slippagePercent,
+    }
+  }, [amount, collateralItems, getDecimals, getSymbol, getFeePercentage, selectedCollateral, slippagePercent])
 
   return (
     <form onSubmit={handleSubmit}>
@@ -139,8 +153,7 @@ const Order = ({ isBuyOrder }) => {
             {isBuyOrder && <StyledTextBlock>{collateralItems[selectedCollateral].symbol} TO SPEND</StyledTextBlock>}
             {!isBuyOrder && <StyledTextBlock>{bondedSymbol} TO SELL</StyledTextBlock>}
           </label>
-          <CombinedInput
-            css={`margin-bottom: 10px;`}>
+          <CombinedInput css="margin-bottom: 10px;">
             <TextInput type="number" value={amount} onChange={handleAmountUpdate} min={0} placeholder="0" step="any" required wide />
             {isBuyOrder ? (
               <span
@@ -161,7 +174,7 @@ const Order = ({ isBuyOrder }) => {
                 against
               </Text>
             )}
-            <DropDown items={[collaterals.primaryCollateral.symbol]} selected={selectedCollateral} onChange={setSelectedCollateral} />
+            <DropDown items={[collaterals.primaryCollateral.symbol]} selected={selectedCollateral} onChange={setSelectedCollateral} css="width: 130px;" />
           </CombinedInput>
           <label>
             <StyledTextBlock>ACCEPTED SLIPPAGE %</StyledTextBlock>
@@ -171,14 +184,7 @@ const Order = ({ isBuyOrder }) => {
       </InputsWrapper>
       <Total
         isBuyOrder={isBuyOrder}
-        amount={{
-          value: amount,
-          decimals: getDecimals(),
-          symbol: getSymbol(),
-          reserveRatio: getReserveRatio(),
-          feePercentage: getFeePercentage(),
-          slippagePercent: slippagePercent
-        }}
+        amount={amountData}
         conversionSymbol={getConversionSymbol()}
         onError={validate}
         setMinReturnAmount={setMinReturnAmount}
@@ -201,7 +207,7 @@ const Order = ({ isBuyOrder }) => {
         `}
       >
         <Info
-          title="Your balance"
+          title={`Your ${isBuyOrder ? '' : 'spendable'} balance`}
           css={`
             margin-bottom: ${2 * GU}px;
           `}
@@ -216,17 +222,18 @@ const Order = ({ isBuyOrder }) => {
           tokenSymbol={isBuyOrder ? bondedSymbol : collateralItems[selectedCollateral].symbol}
         />
 
-        {getFeePercentage() > 0 && <Info
-          title={`Fee (${getFeePercentage()}%)`}
-          css={`
-            margin-top: ${2 * GU}px;
-          `}
-        >
-          <p>
-            {`A fee of ${feeAmount} ${collateralItems[selectedCollateral].symbol} will be sent directly to the organisation's funding pool.`}
-          </p>
-        </Info>}
-
+        {getFeePercentage() > 0 && (
+          <Info
+            title={`Fee (${getFeePercentage()}%)`}
+            css={`
+              margin-top: ${2 * GU}px;
+            `}
+          >
+            <p>{`A fee of ${formatBigNumber(feeAmount, 0)} ${
+              collateralItems[selectedCollateral].symbol
+            } will be sent directly to the organisation's funding pool.`}</p>
+          </Info>
+        )}
       </div>
     </form>
   )

--- a/apps/aragon-fundraising/app/src/components/NewOrder/Order.js
+++ b/apps/aragon-fundraising/app/src/components/NewOrder/Order.js
@@ -85,7 +85,6 @@ const Order = ({ isBuyOrder }) => {
     if (valid) {
       const amountBn = toDecimals(amount, isBuyOrder ? collateralItems[selectedCollateral].decimals : bondedDecimals).toFixed()
 
-      console.log('minReturnAmount', minReturnAmount)
       const minReturnBn = toDecimals(minReturnAmount, isBuyOrder ? bondedDecimals : collateralItems[selectedCollateral].decimals).toFixed()
       if (isBuyOrder) {
         const intent = { token: { address, value: amountBn, spender: marketMaker } }

--- a/apps/aragon-fundraising/app/src/helpers.js/tokens.js
+++ b/apps/aragon-fundraising/app/src/helpers.js/tokens.js
@@ -1,0 +1,15 @@
+import minimeTokenAbi from '../abi/MiniMeToken.json'
+import tokenManagerAbi from '../abi/token-manager.json'
+
+export async function spendableBalanceOf(tokenAddress, connectedAccount, api) {
+  const tokenManagerAddress = await api
+    .external(tokenAddress, minimeTokenAbi)
+    .controller()
+    .toPromise()
+  const spendableBalanceOf = await api
+    .external(tokenManagerAddress, tokenManagerAbi)
+    .spendableBalanceOf(connectedAccount)
+    .toPromise()
+
+  return spendableBalanceOf
+}

--- a/apps/aragon-fundraising/app/src/utils/bn-utils.js
+++ b/apps/aragon-fundraising/app/src/utils/bn-utils.js
@@ -1,5 +1,7 @@
 import BigNumber from 'bignumber.js'
 
+const FORMAT = { groupSize: 3, decimalSeparator: '.' }
+
 /**
  * Converts a monthly rate to its tap rate (wei/block)
  * @param {String|Number|BigNumber} value - value to convert
@@ -43,9 +45,10 @@ export const fromDecimals = (value, decimals) => {
  * @param {String} opts.numberSuffix - suffix to put at the end, default ''
  * @returns {String} the formatted value
  */
-export const formatBigNumber = (value, decimals, { dp = 2, rm = 1, keepSign = false, numberPrefix = '', numberSuffix = '' } = {}) => {
+export const formatBigNumber = (value, decimals, { dp = 2, rm = 1, keepSign = false, numberPrefix = '', numberSuffix = '', commify = true } = {}) => {
   const valueDecimals = fromDecimals(value, decimals)
   const sign = valueDecimals.isPositive() ? '+' : '-'
   const prefix = keepSign ? `${sign}${numberPrefix}` : `${numberPrefix}`
-  return `${prefix}${valueDecimals.abs().toFormat(dp, rm)}${numberSuffix}`
+
+  return `${prefix}${valueDecimals.abs().toFormat(dp, rm, { ...FORMAT, groupSeparator: commify ? ',' : '' })}${numberSuffix}`
 }


### PR DESCRIPTION
closes #10 

- Frontend now tracks users's spendable balance of bonded token as opposed to full balance.
- Prevented "commifying" some amounts used to compute other values (e.g `feeAmount`) which caused `NAN`s when amounts were greater than `1000`.
- Memoized all posible functions and objects to prevent some unnecessary re-renders
- Rounded slippage to 2 places