### PR TITLE
Settings tab: Buy/Sell Fees

### DIFF
--- a/apps/aragon-fundraising/app/src/components/DefinitionsBox.js
+++ b/apps/aragon-fundraising/app/src/components/DefinitionsBox.js
@@ -4,7 +4,12 @@ import { Box, GU, useTheme } from '@aragon/ui'
 const DefinitionsBox = ({ heading, definitions }) => {
   const theme = useTheme()
   return (
-    <Box heading={heading}>
+    <Box
+      heading={heading}
+      css={`
+        height: 100%;
+      `}
+    >
       <ul>
         {definitions.map(({ label, content }, index) => (
           <li

--- a/apps/aragon-fundraising/app/src/components/Fees/EditFees.js
+++ b/apps/aragon-fundraising/app/src/components/Fees/EditFees.js
@@ -1,0 +1,100 @@
+import React, { useCallback, useState } from 'react'
+import { Button, Field, GU, SidePanel, TextInput, useTheme } from '@aragon/ui'
+import { useAragonApi } from '@aragon/api-react'
+import { percetangeToBase } from '../../utils/bn-utils'
+
+const EditFees = ({ buyFeePct: initialBuyFeePct, opened, onClosePanel, sellFeePct: initialSellFeePct }) => {
+  const { api, appState } = useAragonApi()
+  const {
+    constants: { PCT_BASE },
+  } = appState
+
+  const [buyFeePct, setBuyFeePct] = useState(initialBuyFeePct)
+  const [sellFeePct, setSellFeePct] = useState(initialSellFeePct)
+
+  const handleBuyFeeChange = useCallback(event => {
+    const newBuyFeePct = event.target.value
+    setBuyFeePct(Math.min(Math.max(newBuyFeePct, 0), 100))
+  }, [])
+
+  const handleSellFeeChange = useCallback(event => {
+    const newSellFeePct = event.target.value
+    setSellFeePct(Math.min(Math.max(newSellFeePct, 0), 100))
+  }, [])
+
+  const handleSubmit = useCallback(
+    event => {
+      event.preventDefault()
+
+      const convertedBuyFees = percetangeToBase(buyFeePct, PCT_BASE)
+      const convertedSellFees = percetangeToBase(sellFeePct, PCT_BASE)
+
+      api.updateFees(convertedBuyFees.toString(), convertedSellFees.toString()).toPromise()
+      onClosePanel()
+    },
+    [api, buyFeePct, onClosePanel, PCT_BASE, sellFeePct]
+  )
+
+  const feesUpdated = buyFeePct !== initialBuyFeePct || sellFeePct !== initialSellFeePct
+
+  return (
+    <SidePanel opened={opened} onClose={onClosePanel} title="Update fees">
+      <form
+        onSubmit={handleSubmit}
+        css={`
+          margin-top: ${3 * GU}px;
+        `}
+      >
+        <Field label="Buy fee">
+          <PercentageInput value={buyFeePct} onChange={handleBuyFeeChange} />
+        </Field>
+        <Field label="Sell fee">
+          <PercentageInput value={sellFeePct} onChange={handleSellFeeChange} />
+        </Field>
+
+        <Button
+          label="Edit fees"
+          mode="strong"
+          type="submit"
+          wide
+          disabled={!feesUpdated}
+          css={`
+            margin-top: ${2 * GU}px;
+          `}
+        />
+      </form>
+    </SidePanel>
+  )
+}
+
+const PercentageInput = ({ value, onChange }) => {
+  const theme = useTheme()
+  const adornmentSettings = { padding: 1 }
+
+  return (
+    <TextInput
+      type="number"
+      value={value}
+      onChange={onChange}
+      wide
+      required
+      min={0}
+      max={100}
+      adornment={
+        <span
+          css={`
+            background: ${theme.background};
+            border-left: 1px solid ${theme.border};
+            padding: 7px ${2 * GU}px;
+          `}
+        >
+          %
+        </span>
+      }
+      adornmentPosition="end"
+      adornmentSettings={adornmentSettings}
+    />
+  )
+}
+
+export default EditFees

--- a/apps/aragon-fundraising/app/src/components/Fees/EditFees.js
+++ b/apps/aragon-fundraising/app/src/components/Fees/EditFees.js
@@ -38,7 +38,7 @@ const EditFees = ({ buyFeePct: initialBuyFeePct, opened, onClosePanel, sellFeePc
   const feesUpdated = buyFeePct !== initialBuyFeePct || sellFeePct !== initialSellFeePct
 
   return (
-    <SidePanel opened={opened} onClose={onClosePanel} title="Update fees">
+    <SidePanel opened={opened} onClose={onClosePanel} title="Edit fees">
       <form
         onSubmit={handleSubmit}
         css={`

--- a/apps/aragon-fundraising/app/src/components/Fees/Fees.js
+++ b/apps/aragon-fundraising/app/src/components/Fees/Fees.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Box, Button, GU, IconEdit, textStyle, useTheme } from '@aragon/ui'
 
-const Fees = ({ buyFeePct, sellFeePct, onRequestEditFees }) => {
+const Fees = ({ buyFeePct, sellFeePct, onRequestUpdateFees }) => {
   return (
     <Box heading="Fees">
       <div>
@@ -12,8 +12,8 @@ const Fees = ({ buyFeePct, sellFeePct, onRequestEditFees }) => {
             margin-top: ${2 * GU}px;
           `}
           icon={<IconEdit />}
-          label="Edit fees"
-          onClick={onRequestEditFees}
+          label="Update Fees"
+          onClick={onRequestUpdateFees}
           wide
         />
       </div>

--- a/apps/aragon-fundraising/app/src/components/Fees/Fees.js
+++ b/apps/aragon-fundraising/app/src/components/Fees/Fees.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import { Box, Button, GU, IconEdit, textStyle, useTheme } from '@aragon/ui'
+
+const Fees = ({ buyFeePct, sellFeePct, onRequestEditFees }) => {
+  return (
+    <Box heading="Fees">
+      <div>
+        <Field label="Buy fee" value={`% ${buyFeePct}`} />
+        <Field label="Sell fee" value={`% ${sellFeePct}`} />
+        <Button
+          css={`
+            margin-top: ${2 * GU}px;
+          `}
+          icon={<IconEdit />}
+          label="Edit fees"
+          onClick={onRequestEditFees}
+          wide
+        />
+      </div>
+    </Box>
+  )
+}
+
+const Field = ({ label, value }) => {
+  const theme = useTheme()
+
+  return (
+    <div
+      css={`
+        margin-bottom: ${2 * GU}px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      `}
+    >
+      <h2
+        css={`
+          color: ${theme.surfaceContentSecondary};
+        `}
+      >
+        {label}
+      </h2>
+
+      <div
+        css={`
+          ${textStyle('body2')};
+        `}
+      >
+        {value}
+      </div>
+    </div>
+  )
+}
+
+export default Fees

--- a/apps/aragon-fundraising/app/src/components/Fees/UpdateFees.js
+++ b/apps/aragon-fundraising/app/src/components/Fees/UpdateFees.js
@@ -1,9 +1,9 @@
 import React, { useCallback, useState } from 'react'
-import { Button, Field, GU, SidePanel, TextInput, useTheme } from '@aragon/ui'
+import { Button, Field, GU, Info, SidePanel, TextInput, useTheme } from '@aragon/ui'
 import { useAragonApi } from '@aragon/api-react'
 import { percetangeToBase } from '../../utils/bn-utils'
 
-const EditFees = ({ buyFeePct: initialBuyFeePct, opened, onClosePanel, sellFeePct: initialSellFeePct }) => {
+const UpdateFees = ({ buyFeePct: initialBuyFeePct, opened, onClosePanel, sellFeePct: initialSellFeePct }) => {
   const { api, appState } = useAragonApi()
   const {
     constants: { PCT_BASE },
@@ -38,13 +38,21 @@ const EditFees = ({ buyFeePct: initialBuyFeePct, opened, onClosePanel, sellFeePc
   const feesUpdated = buyFeePct !== initialBuyFeePct || sellFeePct !== initialSellFeePct
 
   return (
-    <SidePanel opened={opened} onClose={onClosePanel} title="Edit fees">
+    <SidePanel opened={opened} onClose={onClosePanel} title="Update Fees">
       <form
         onSubmit={handleSubmit}
         css={`
           margin-top: ${3 * GU}px;
         `}
       >
+        <Info
+          css={`
+            margin-bottom: ${2 * GU}px;
+          `}
+          title="Action"
+        >
+          Update the fee taken from all buy/sell orders that is deposited into the organisation's funding pool
+        </Info>
         <Field label="Buy fee">
           <PercentageInput value={buyFeePct} onChange={handleBuyFeeChange} />
         </Field>
@@ -53,7 +61,7 @@ const EditFees = ({ buyFeePct: initialBuyFeePct, opened, onClosePanel, sellFeePc
         </Field>
 
         <Button
-          label="Edit fees"
+          label="Update Fees"
           mode="strong"
           type="submit"
           wide
@@ -97,4 +105,4 @@ const PercentageInput = ({ value, onChange }) => {
   )
 }
 
-export default EditFees
+export default UpdateFees

--- a/apps/aragon-fundraising/app/src/screens/Reserves.js
+++ b/apps/aragon-fundraising/app/src/screens/Reserves.js
@@ -1,19 +1,18 @@
-import React, { useEffect, useState } from 'react'
-import { Box, Button, Field, GU, Help, Info, SidePanel, Split, TextInput, textStyle, TokenBadge, useLayout, useTheme, IdentityBadge } from '@aragon/ui'
-import { useApi, useAppState } from '@aragon/api-react'
-import { differenceInMonths } from 'date-fns'
-import EditIcon from '../assets/EditIcon.svg'
+import React, { useCallback, useState } from 'react'
+import { useAppState } from '@aragon/api-react'
+import { Box, GU, Help, IdentityBadge, Split, textStyle, TokenBadge, useLayout, useTheme } from '@aragon/ui'
 import DefinitionsBox from '../components/DefinitionsBox'
-import { formatBigNumber, fromMonthlyAllocation, toMonthlyAllocation, toDecimals, fromDecimals } from '../utils/bn-utils'
-import ValidationError from '../components/ValidationError'
+import EditFees from '../components/Fees/EditFees'
+import Fees from '../components/Fees/Fees'
+import { formatBigNumber, percentageFromBase } from '../utils/bn-utils'
 
 // In this copy we should display the user the percentage of max increase of the tap
-const helpContent = (tokenSymbol) => {
+const helpContent = tokenSymbol => {
   return [
     [
       'What is the collateralization ratio?',
       'The collateralization ratio defines the ratio between the amount of collateral in your market-maker reserve and the market cap of this marketplace.',
-    ]
+    ],
   ]
 }
 
@@ -61,21 +60,28 @@ export default () => {
   // *****************************
   const {
     constants: { PPM, PCT_BASE },
+    values: { buyFeePct, sellFeePct },
     collaterals: {
-      primaryCollateral: {
-        address: primaryCollateralAddress,
-        reserveRatio: primaryCollateralReserveRatio,
-        symbol: primaryCollateralSymbol,
-        decimals: primaryCollateralDecimals,
-      },
+      primaryCollateral: { reserveRatio: primaryCollateralReserveRatio, symbol: primaryCollateralSymbol },
     },
     bondedToken: { name, symbol, decimals: tokenDecimals, address, realSupply },
   } = useAppState()
 
   // *****************************
-  // aragon api
+  // internal state
   // *****************************
-  const api = useApi()
+
+  const theme = useTheme()
+  const { layoutName } = useLayout()
+
+  const [panelOpened, setPanelOpened] = useState(false)
+
+  const handlePanelOpen = useCallback(() => {
+    setPanelOpened(true)
+  }, [])
+  const handlePanelClose = useCallback(() => {
+    setPanelOpened(false)
+  }, [])
 
   // *****************************
   // human readable values
@@ -83,15 +89,8 @@ export default () => {
   const adjustedTokenSupply = formatBigNumber(realSupply, tokenDecimals)
   const primaryCollateralRatio = formatBigNumber(primaryCollateralReserveRatio.div(PPM).times(100), 0)
 
-  // *****************************
-  // internal state
-  // *****************************
-  const [opened, setOpened] = useState(false)
-
-  const theme = useTheme()
-  const { layoutName } = useLayout()
-
-  const editMonthlyAllocationButton = <Button icon={<img src={EditIcon} />} label="Update fees" onClick={() => setOpened(true)} />
+  const adjustedBuyFeePct = percentageFromBase(buyFeePct, PCT_BASE)
+  const adjustedSellFee = percentageFromBase(sellFeePct, PCT_BASE)
 
   return (
     <>
@@ -107,9 +106,7 @@ export default () => {
                   width: 100%;
                 `}
               >
-                {[
-                  [primaryCollateralSymbol, primaryCollateralRatio],
-                ].map(([symbol, ratio], i) => (
+                {[[primaryCollateralSymbol, primaryCollateralRatio]].map(([symbol, ratio], i) => (
                   <ReserveSetting
                     key={i}
                     label={`${symbol} collateralization ratio`}
@@ -134,62 +131,23 @@ export default () => {
           </>
         }
         secondary={
-          <DefinitionsBox
-            heading="Shares"
-            definitions={[
-              { label: 'Total Supply', content: <strong>{adjustedTokenSupply}</strong> },
-              {
-                label: 'Token',
-                content: <TokenBadge name={name} symbol={symbol} badgeOnly />,
-              },
-              { label: 'Address', content: <IdentityBadge entity={address} /> },
-            ]}
-          />
+          <>
+            <DefinitionsBox
+              heading="Shares"
+              definitions={[
+                { label: 'Total Supply', content: <strong>{adjustedTokenSupply}</strong> },
+                {
+                  label: 'Token',
+                  content: <TokenBadge name={name} symbol={symbol} badgeOnly />,
+                },
+                { label: 'Address', content: <IdentityBadge entity={address} /> },
+              ]}
+            />
+            <Fees onRequestEditFees={handlePanelOpen} buyFeePct={adjustedBuyFeePct} sellFeePct={adjustedSellFee} />
+          </>
         }
       />
-      {/*TODO: Convert to update buy/sell fees*/}
-      <SidePanel opened={opened} onClose={() => setOpened(false)} title="Monthly allocation">
-        <form
-          css={`
-            margin-top: ${3 * GU}px;
-          `}
-        >
-          {/*<Field label={`Rate (${primaryCollateralSymbol})`}>*/}
-          {/*  <TextInput type="number" value={newRate} onChange={handleMonthlyChange} wide required />*/}
-          {/*</Field>*/}
-          {/*<Field label={`Floor (${primaryCollateralSymbol})`}>*/}
-          {/*  <TextInput type="number" value={newFloor} onChange={handleFloorChange} wide required />*/}
-          {/*</Field>*/}
-          {/*<Button mode="strong" type="submit" disabled={!valid} wide>*/}
-          {/*  Save monthly allocation*/}
-          {/*</Button>*/}
-          {/*{errorMessages?.length > 0 && <ValidationError messages={errorMessages} />}*/}
-
-          {/*<Info*/}
-          {/*  title="Info"*/}
-          {/*  css={`*/}
-          {/*    margin-top: ${2 * GU}px;*/}
-          {/*  `}*/}
-          {/*>*/}
-          {/*  <p>*/}
-          {/*    You can increase the rate by <b>{displayRateIncrease}%</b> up to <b>{adjustedMaxRate} {primaryCollateralSymbol}</b>.*/}
-          {/*  </p>*/}
-          {/*  <p>*/}
-          {/*    You can decrease the floor by <b>{displayFloorIncrease}%</b> down to <b>{adjustedMinFloor} {primaryCollateralSymbol}</b>.*/}
-          {/*  </p>*/}
-          {/*</Info>*/}
-          {/*<Info*/}
-          {/*  mode="warning"*/}
-          {/*  title="Warning"*/}
-          {/*  css={`*/}
-          {/*    margin-top: ${2 * GU}px;*/}
-          {/*  `}*/}
-          {/*>*/}
-          {/*  You can update either the tap rate or floor only once a month. If you do update the tap rate or floor now{' '}*/}
-          {/*  <b>you will not be able to update either of them again before a month</b>. Act wisely.*/}
-          {/*</Info>*/}
-        </form>
-      </SidePanel>
+      <EditFees opened={panelOpened} onClosePanel={handlePanelClose} buyFeePct={adjustedBuyFeePct} sellFeePct={adjustedSellFee} />
     </>
   )
 }

--- a/apps/aragon-fundraising/app/src/screens/Reserves.js
+++ b/apps/aragon-fundraising/app/src/screens/Reserves.js
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react'
 import { useAppState } from '@aragon/api-react'
 import { Box, GU, Help, IdentityBadge, Split, textStyle, TokenBadge, useLayout, useTheme } from '@aragon/ui'
 import DefinitionsBox from '../components/DefinitionsBox'
-import EditFees from '../components/Fees/EditFees'
+import UpdateFees from '../components/Fees/UpdateFees'
 import Fees from '../components/Fees/Fees'
 import { formatBigNumber, percentageFromBase } from '../utils/bn-utils'
 
@@ -94,60 +94,61 @@ export default () => {
 
   return (
     <>
-      <Split
-        primary={
-          <>
-            <Box heading="Collateralization ratios">
-              <div
-                css={`
-                  display: grid;
-                  grid-column-gap: ${3 * GU}px;
-                  grid-template-columns: repeat(${layoutName === 'small' ? '1' : '2'}, 1fr);
-                  width: 100%;
-                `}
-              >
-                {[[primaryCollateralSymbol, primaryCollateralRatio]].map(([symbol, ratio], i) => (
-                  <ReserveSetting
-                    key={i}
-                    label={`${symbol} collateralization ratio`}
-                    helpContent={helpContent(primaryCollateralSymbol)[0]}
-                    value={
-                      <span>
-                        {ratio}
-                        <span
-                          css={`
-                            margin-left: ${0.5 * GU}px;
-                            color: ${theme.surfaceContentSecondary};
-                          `}
-                        >
-                          %
-                        </span>
-                      </span>
-                    }
-                  />
-                ))}
-              </div>
-            </Box>
-          </>
-        }
-        secondary={
-          <>
-            <DefinitionsBox
-              heading="Shares"
-              definitions={[
-                { label: 'Total Supply', content: <strong>{adjustedTokenSupply}</strong> },
-                {
-                  label: 'Token',
-                  content: <TokenBadge name={name} symbol={symbol} badgeOnly />,
-                },
-                { label: 'Address', content: <IdentityBadge entity={address} /> },
-              ]}
-            />
-            <Fees onRequestEditFees={handlePanelOpen} buyFeePct={adjustedBuyFeePct} sellFeePct={adjustedSellFee} />
-          </>
-        }
-      />
-      <EditFees opened={panelOpened} onClosePanel={handlePanelClose} buyFeePct={adjustedBuyFeePct} sellFeePct={adjustedSellFee} />
+      <div
+        css={`
+          display: grid;
+          grid-template-columns: auto 1fr 1fr;
+          grid-gap: ${2 * GU}px;
+        `}
+      >
+        <Box heading="Collateralization ratios">
+          <div
+            css={`
+              display: grid;
+              grid-column-gap: ${3 * GU}px;
+              grid-template-columns: repeat(${layoutName === 'small' ? '1' : '2'}, 1fr);
+              width: 100%;
+            `}
+          >
+            {[[primaryCollateralSymbol, primaryCollateralRatio]].map(([symbol, ratio], i) => (
+              <ReserveSetting
+                key={i}
+                label={`${symbol} collateralization ratio`}
+                helpContent={helpContent(primaryCollateralSymbol)[0]}
+                value={
+                  <span>
+                    {ratio}
+                    <span
+                      css={`
+                        margin-left: ${0.5 * GU}px;
+                        color: ${theme.surfaceContentSecondary};
+                      `}
+                    >
+                      %
+                    </span>
+                  </span>
+                }
+              />
+            ))}
+          </div>
+        </Box>
+
+        <div>
+          <DefinitionsBox
+            heading="Shares"
+            definitions={[
+              { label: 'Total Supply', content: <strong>{adjustedTokenSupply}</strong> },
+              {
+                label: 'Token',
+                content: <TokenBadge name={name} symbol={symbol} badgeOnly />,
+              },
+              { label: 'Address', content: <IdentityBadge entity={address} /> },
+            ]}
+          />
+        </div>
+        <Fees onRequestUpdateFees={handlePanelOpen} buyFeePct={adjustedBuyFeePct} sellFeePct={adjustedSellFee} />
+      </div>
+      <UpdateFees opened={panelOpened} onClosePanel={handlePanelClose} buyFeePct={adjustedBuyFeePct} sellFeePct={adjustedSellFee} />
     </>
   )
 }

--- a/apps/aragon-fundraising/app/src/script.js
+++ b/apps/aragon-fundraising/app/src/script.js
@@ -267,7 +267,7 @@ const loadContractsData = async (state, { bondedToken, marketMaker, presale, net
       symbol,
       name,
       decimals: parseInt(decimals, 10),
-      totalSupply
+      totalSupply,
       // realSupply and overallSupply will be calculated on the reducer
     },
   }
@@ -362,7 +362,14 @@ const removeCollateralToken = (state, { collateral }) => {
 //   }
 // }
 
-const newOrder = async (state, { buyer, seller, collateral, purchaseAmount, sellAmount, returnedAmount, fee, feePct }, settings, blockNumber, transactionHash, logIndex) => {
+const newOrder = async (
+  state,
+  { buyer, seller, collateral, purchaseAmount, sellAmount, returnedAmount, fee, feePct },
+  settings,
+  blockNumber,
+  transactionHash,
+  logIndex
+) => {
   const orders = cloneDeep(state.orders)
   // if it's a buy order, seller and sellAmount will undefined
   // if it's a sell order, buyer and purchaseAmount will be undefined
@@ -382,8 +389,8 @@ const newOrder = async (state, { buyer, seller, collateral, purchaseAmount, sell
     user: buyer || seller,
     type,
     state: Order.state.CLAIMED,
-    amount: sellAmount ? sellAmount : returnedAmount,
-    value: purchaseAmount ? purchaseAmount : returnedAmount,
+    amount: sellAmount || returnedAmount,
+    value: purchaseAmount || returnedAmount,
     fee, // can be undefined
     feePct, // can be undefined
     // price is calculated in the reducer
@@ -516,7 +523,7 @@ const updateFees = (state, { buyFeePct, sellFeePct }) => {
     values: {
       ...state.values,
       buyFeePct,
-      sellFeePct
+      sellFeePct,
     },
   }
 }

--- a/apps/aragon-fundraising/app/src/utils/bn-utils.js
+++ b/apps/aragon-fundraising/app/src/utils/bn-utils.js
@@ -49,3 +49,23 @@ export const formatBigNumber = (value, decimals, { dp = 2, rm = 1, keepSign = fa
   const prefix = keepSign ? `${sign}${numberPrefix}` : `${numberPrefix}`
   return `${prefix}${valueDecimals.abs().toFormat(dp, rm)}${numberSuffix}`
 }
+
+/**
+ * Adjusts the pct from pctBase
+ * @param {BigNum} pct The pct to adjust
+ * @param {BigNum} pctBase The base percentage
+ * @returns {Number} The percantage adjusted from pct base
+ */
+export const percentageFromBase = (pct, pctBase) => {
+  return parseInt(pct.div(pctBase.div(new BigNumber(100))))
+}
+
+/**
+ * Adjusts the pct to pctBase
+ * @param {Number} pct The pct to adjust
+ * @param {BigNum} pctBase The base percentage
+ * @returns {BigNum} The percantage adjusted to pct base
+ */
+export const percetangeToBase = (pct, pctBase) => {
+  return new BigNumber(pct).times(pctBase.div(new BigNumber(100)))
+}


### PR DESCRIPTION
fixes #9 

Includes Buy/Sell fees basic panel with the option to edit them and Side panel for editing.


**Preview**

![Screen Shot 2020-05-28 at 3 06 03 PM](https://user-images.githubusercontent.com/22663232/83177064-d4bf6980-a0f4-11ea-9caf-12580445e92d.png)

![Screen Shot 2020-05-28 at 2 34 55 PM](https://user-images.githubusercontent.com/22663232/83177095-e143c200-a0f4-11ea-9d93-b09081ca0fcd.png)
